### PR TITLE
Update readme to specify next js version needed to use library

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ React Component to highlight interactive zones in images
 6. New Properties: Natural Dimensions, RerenderProps       
 7. Image Reference in Width, Height and onLoad function to access image properties  
 8. Responsive Image Mapper   
-9. Compatible with Next.js        
+9. Compatible with Next.js version ≤ 9.0.0
 ```        
 
 ## Installation


### PR DESCRIPTION
Tried out multiple versions of Next js with react-img-mapper. Concluded that the newest version of Next js that can be used is 9.0.0. Anything later than 9.0.0 will either not load the mapper image at all or will load once and then not work after that. Added to readme to show Next js version support so that users are aware as I had to find out through trial and error. 